### PR TITLE
User 디폴트 생성자 추가

### DIFF
--- a/app/src/main/java/com/hppk/toctw/data/model/User.kt
+++ b/app/src/main/java/com/hppk/toctw/data/model/User.kt
@@ -1,9 +1,9 @@
 package com.hppk.toctw.data.model
 
 data class User (
-    val id: String,
-    val email: String,
-    val name: String,
+    val id: String = "",
+    val email: String = "",
+    val name: String = "",
     val role: Role = Role.STAFF
 )
 


### PR DESCRIPTION
Firestore에서 데이터를 가져오기 위해서는 디폴트 생성자가 필요합니다.

@hyeongjudev, Booth 작업하실 때 Booth도 디폴트 생성자 추가하셔야 합니다. 참고하세요