### PR TITLE
Collapsedlayout 적용된 화면의 테마 변경

### DIFF
--- a/app/src/main/res/layout/activity_booth_details.xml
+++ b/app/src/main/res/layout/activity_booth_details.xml
@@ -10,7 +10,7 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbarLayout"
@@ -31,7 +31,7 @@
 
             <TextView
                 android:id="@+id/tvLabelInfo"
-                android:background="@color/whiteTransparent"
+                android:background="@color/colorPrimaryTransparent"
                 style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_info_lunch.xml
+++ b/app/src/main/res/layout/fragment_info_lunch.xml
@@ -10,7 +10,7 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbarLayout"
@@ -30,7 +30,7 @@
 
             <TextView
                 android:id="@+id/tvLabelInfo"
-                android:background="@color/whiteTransparent"
+                android:background="@color/colorPrimaryTransparent"
                 style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -49,7 +49,7 @@
                 android:layout_gravity="bottom|end"
                 android:gravity="center"
                 android:text="5F Cafeteria"
-                android:textColor="@android:color/black"
+                android:textColor="@android:color/white"
                 app:layout_collapseMode="parallax" />
 
             <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/fragment_info_schedule.xml
+++ b/app/src/main/res/layout/fragment_info_schedule.xml
@@ -10,7 +10,7 @@
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/ThemeOverlay.AppCompat.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbarLayout"
@@ -30,7 +30,7 @@
 
             <TextView
                 android:id="@+id/tvLabelInfo"
-                android:background="@color/whiteTransparent"
+                android:background="@color/colorPrimaryTransparent"
                 style="@style/TextAppearance.AppCompat.Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="colorPrimary">#0197D7</color>
     <color name="colorPrimaryDark">#0171AD</color>
     <color name="colorAccent">#D81B60</color>
-    <color name="colorPrimaryTransparent">#80008577</color>
+    <color name="colorPrimaryTransparent">#E00197D7</color>
 
     <color name="grayVeryLight">#fafafa</color>
     <color name="grayLight">#e0e0e0</color>


### PR DESCRIPTION
* 기존에는 Collapsed되었을 때 상단 타이틀이 검정색으로 나와서 앱의 전체적인 색상과 맞지 않았습니다. (흰색)
Dark 테마로 변경하여 흰색으로 통일시켰습니다.

* 변경하면서 Expanded 상태에서의 text가 영향을 받아 같이 수정하였습니다.
  - 기존 흰 바탕의 검정 글씨에서, primarycolor 바탕에 흰 글씨로 변경되었습니다.

이 변경 사항에 영향 받는 ui는 Booth details, Info lunch, Info schedule 입니다.