### PR TITLE
Chlid의 avatar 이미지 저장을 res id 방식에서 res name으로 변경

### DIFF
--- a/app/src/main/java/com/hppk/toctw/common/Commons.kt
+++ b/app/src/main/java/com/hppk/toctw/common/Commons.kt
@@ -1,6 +1,17 @@
 package com.hppk.toctw.common
 
+import android.content.Context
+import com.hppk.toctw.R
 import java.text.SimpleDateFormat
 import java.util.*
 
 val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.KOREA)
+
+fun Context.getAvatarResId(resName: String): Int {
+    var imgResId = resources.getIdentifier(resName, "drawable", packageName)
+    if (imgResId == 0) {
+        imgResId = R.drawable.ic_unknown_kid
+    }
+
+    return imgResId
+}

--- a/app/src/main/java/com/hppk/toctw/data/model/Stamp.kt
+++ b/app/src/main/java/com/hppk/toctw/data/model/Stamp.kt
@@ -24,8 +24,11 @@ data class Stamp(
 data class Child(
     @PrimaryKey
     val name: String = "",
-    var avatar: Int = 0
+    var avatar: String= DEFAULT_AVATAR
 ) : Parcelable
+
+const val DEFAULT_AVATAR = "ic_boy"
+const val DEFAULT_UNKNOWN_AVATAR = "ic_unknown_kid"
 
 @Entity(
     tableName = "child_stamp_join",

--- a/app/src/main/java/com/hppk/toctw/ui/children/ChildrenAdapter.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/ChildrenAdapter.kt
@@ -1,16 +1,21 @@
 package com.hppk.toctw.ui.children
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.hppk.toctw.R
+import com.hppk.toctw.common.getAvatarResId
 import com.hppk.toctw.data.model.Child
+import com.hppk.toctw.data.model.DEFAULT_AVATAR
+import com.hppk.toctw.data.model.DEFAULT_UNKNOWN_AVATAR
 import kotlinx.android.synthetic.main.item_child.view.*
 
 
 class ChildrenAdapter(
+    private val context: Context,
     val children: MutableList<Child> = mutableListOf(),
     var viewWidth: Int = 1080,
     private val childListener: ChildClickListener
@@ -50,8 +55,8 @@ class ChildrenAdapter(
         val child = children[position]
         holder.itemView.tvChildName.text = child.name
 
-        val avatarResId = if (child.avatar == 0) R.drawable.ic_boy else child.avatar
-        holder.itemView.ivAvatar.setImageResource(avatarResId)
+        val avatarResName = if (child.avatar == DEFAULT_UNKNOWN_AVATAR) DEFAULT_AVATAR else child.avatar
+        holder.itemView.ivAvatar.setImageResource(context.getAvatarResId(avatarResName))
         holder.itemView.ivDeleteChild.setOnClickListener {
             childListener.deleteChild(child)
         }

--- a/app/src/main/java/com/hppk/toctw/ui/children/ChildrenFragment.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/ChildrenFragment.kt
@@ -44,7 +44,7 @@ class ChildrenFragment : Fragment(), ChildrenContract.View, ChildrenAdapter.Chil
         val helper = PagerSnapHelper()
         helper.attachToRecyclerView(rvChildren)
 
-        adapter = ChildrenAdapter(childListener = this)
+        adapter = ChildrenAdapter(context!!, childListener = this)
 
         rvChildren.layoutManager = LinearLayoutManager(context, RecyclerView.HORIZONTAL, false)
         rvChildren.adapter = adapter

--- a/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildContract.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildContract.kt
@@ -9,6 +9,6 @@ interface AddChildContract {
 
     interface Presenter {
         fun unsubscribe()
-        fun saveChild(childName: String, avatarResId: Int)
+        fun saveChild(childName: String, avatarResName: String)
     }
 }

--- a/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildFragment.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildFragment.kt
@@ -14,14 +14,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import com.hppk.toctw.R
+import com.hppk.toctw.common.getAvatarResId
 import com.hppk.toctw.data.model.Child
+import com.hppk.toctw.data.model.DEFAULT_AVATAR
+import com.hppk.toctw.data.model.DEFAULT_UNKNOWN_AVATAR
 import com.hppk.toctw.data.repository.ChildrenRepository
 import com.hppk.toctw.data.source.local.AppDatabase
 import kotlinx.android.synthetic.main.fragment_add_child.*
 
 
 class SharedViewModel : ViewModel() {
-    val avatarResId = MutableLiveData<Int>()
+    val avatarResName = MutableLiveData<String>()
 }
 
 class AddChildFragment : Fragment(), AddChildContract.View {
@@ -40,9 +43,9 @@ class AddChildFragment : Fragment(), AddChildContract.View {
             ViewModelProviders.of(this)[SharedViewModel::class.java]
         } ?: throw Exception("Invalid Activity")
 
-        model.avatarResId.observe(this, Observer<Int> { avatarResId ->
-            if (avatarResId != 0) {
-                ivUnknownAvatar.setImageResource(avatarResId)
+        model.avatarResName.observe(this, Observer<String> { avatarResName ->
+            if (avatarResName != "ic_unknown_kid") {
+                ivUnknownAvatar.setImageResource(context!!.getAvatarResId(avatarResName))
             }
         })
 
@@ -66,7 +69,7 @@ class AddChildFragment : Fragment(), AddChildContract.View {
         ivUnknownAvatar.setOnClickListener { showAvatarSelectDialog() }
 
         btnDone.setOnClickListener {
-            presenter.saveChild(etName.text.toString(), model.avatarResId.value ?: R.drawable.ic_boy)
+            presenter.saveChild(etName.text.toString(), model.avatarResName.value ?: DEFAULT_AVATAR)
 
             etName.setText("")
             ivUnknownAvatar.setImageResource(R.drawable.ic_unknown_kid)
@@ -85,7 +88,7 @@ class AddChildFragment : Fragment(), AddChildContract.View {
 
     override fun onDestroy() {
         super.onDestroy()
-        model.avatarResId.value = 0
+        model.avatarResName.value = DEFAULT_UNKNOWN_AVATAR
         presenter.unsubscribe()
     }
 

--- a/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildPresenter.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/add/AddChildPresenter.kt
@@ -22,8 +22,8 @@ class AddChildPresenter (
         disposable.clear()
     }
 
-    override fun saveChild(childName: String, avatarResId: Int) {
-        val child = Child(childName, avatarResId)
+    override fun saveChild(childName: String, avatarResName: String) {
+        val child = Child(childName, avatarResName)
         disposable.add(
             childrenRepository.save(child)
                 .subscribeOn(ioScheduler)

--- a/app/src/main/java/com/hppk/toctw/ui/children/avatars/AvatarsAdapter.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/avatars/AvatarsAdapter.kt
@@ -1,19 +1,22 @@
 package com.hppk.toctw.ui.children.avatars
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.hppk.toctw.R
+import com.hppk.toctw.common.getAvatarResId
 import kotlinx.android.synthetic.main.item_avatar.view.*
 
 class AvatarsAdapter(
-    private val avatars: List<Int>,
+    private val context: Context,
+    private val avatars: List<String>,
     private val listener: AvatarClickListener
 ) : RecyclerView.Adapter<AvatarsAdapter.AvatarHolder>() {
 
     interface AvatarClickListener {
-        fun onAvatarClicked(resId: Int)
+        fun onAvatarClicked(resName: String)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = AvatarHolder(
@@ -23,10 +26,11 @@ class AvatarsAdapter(
     override fun getItemCount(): Int = avatars.size
 
     override fun onBindViewHolder(holder: AvatarHolder, position: Int) {
-        val resId = avatars[position]
-        holder.itemView.ivAvatar.setImageResource(resId)
+        val resName = avatars[position]
+
+        holder.itemView.ivAvatar.setImageResource(context.getAvatarResId(resName))
         holder.itemView.ivAvatar.setOnClickListener {
-            listener.onAvatarClicked(resId)
+            listener.onAvatarClicked(resName)
         }
     }
 

--- a/app/src/main/java/com/hppk/toctw/ui/children/avatars/AvatarsDialog.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/children/avatars/AvatarsDialog.kt
@@ -17,23 +17,24 @@ class AvatarsDialog : DialogFragment(), AvatarsAdapter.AvatarClickListener {
 
     private val adapter: AvatarsAdapter by lazy {
         AvatarsAdapter(
+            context!!,
             listOf(
-                R.drawable.ic_boy,
-                R.drawable.ic_boy2,
-                R.drawable.ic_girl,
-                R.drawable.ic_girl2,
-                R.drawable.ic_boy3,
-                R.drawable.ic_boy4,
-                R.drawable.ic_girl3,
-                R.drawable.ic_girl4,
-                R.drawable.ic_boy5,
-                R.drawable.ic_boy6,
-                R.drawable.ic_girl5,
-                R.drawable.ic_girl6,
-                R.drawable.ic_boy7,
-                R.drawable.ic_boy8,
-                R.drawable.ic_girl7,
-                R.drawable.ic_girl8
+                "ic_boy",
+                "ic_boy2",
+                "ic_girl",
+                "ic_girl2",
+                "ic_boy3",
+                "ic_boy4",
+                "ic_girl3",
+                "ic_girl4",
+                "ic_boy5",
+                "ic_boy6",
+                "ic_girl5",
+                "ic_girl6",
+                "ic_boy7",
+                "ic_boy8",
+                "ic_girl7",
+                "ic_girl8"
             ),
             this
         )
@@ -60,8 +61,8 @@ class AvatarsDialog : DialogFragment(), AvatarsAdapter.AvatarClickListener {
         rvAvatars.adapter = adapter
     }
 
-    override fun onAvatarClicked(resId: Int) {
-        model.avatarResId.value = resId
+    override fun onAvatarClicked(resName: String) {
+        model.avatarResName.value = resName
         dismiss()
     }
 

--- a/app/src/main/java/com/hppk/toctw/ui/stamps/StampsFragment.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/stamps/StampsFragment.kt
@@ -15,6 +15,8 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.transition.TransitionInflater
 import com.hppk.toctw.R
+import com.hppk.toctw.common.getAvatarResId
+import com.hppk.toctw.data.model.DEFAULT_UNKNOWN_AVATAR
 import com.hppk.toctw.data.repository.StampRepository
 import com.hppk.toctw.data.source.local.AppDatabase
 import kotlinx.android.synthetic.main.fragment_stamps.*
@@ -49,8 +51,8 @@ class StampsFragment : Fragment(), StampsContract.View {
         initToolbar()
         initView()
 
-        if (args.child.avatar != 0) {
-            ivAvatar.setImageResource(args.child.avatar)
+        if (args.child.avatar != DEFAULT_UNKNOWN_AVATAR) {
+            ivAvatar.setImageResource(context!!.getAvatarResId(args.child.avatar))
         }
 
         presenter.getStamps(args.child)


### PR DESCRIPTION
avatar 이미지를 resource id를 저장하는 방식에서 간혹 문제가 발생하는 것이 확인되었습니다.
resource name으로 저장하도록 수정하였습니다.