### PR TITLE
전체 Review 리스트를 보여줄 수 있는 별도 화면 분리

### DIFF
--- a/app/src/main/java/com/hppk/toctw/data/repository/ReviewRepository.kt
+++ b/app/src/main/java/com/hppk/toctw/data/repository/ReviewRepository.kt
@@ -7,9 +7,11 @@ import io.reactivex.Completable
 import io.reactivex.Single
 
 class ReviewRepository(
-    private val reviewDao: FirestoreReviewDao
+    private val reviewDao: FirestoreReviewDao = FirestoreReviewDao()
 ) {
     fun save(booth: Booth, review: Review): Completable = reviewDao.save(booth, review)
+
+    fun getLittleReviews(booth: Booth): Single<List<Review>> = reviewDao.getLittleReviews(booth)
 
     fun getReviews(booth: Booth): Single<List<Review>> = reviewDao.getReviews(booth)
 }

--- a/app/src/main/java/com/hppk/toctw/data/source/ReviewDao.kt
+++ b/app/src/main/java/com/hppk/toctw/data/source/ReviewDao.kt
@@ -8,5 +8,6 @@ import io.reactivex.Single
 interface ReviewDao {
 
     fun save(booth: Booth, review: Review): Completable
+    fun getLittleReviews(booth: Booth): Single<List<Review>>
     fun getReviews(booth: Booth): Single<List<Review>>
 }

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/BoothDetailsContract.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/BoothDetailsContract.kt
@@ -8,11 +8,13 @@ interface BoothDetailsContract {
         fun onReviewsLoaded(reviews: List<Review>)
         fun onEmptyReviewsLoaded()
         fun showSignInButton(visible: Int)
+        fun showMoreReviewButton(show: Boolean)
     }
 
     interface Presenter {
         fun unsubscribe()
         fun isSignedIn()
         fun getReviews(booth: Booth)
+        fun getReviewsMore(booth: Booth)
     }
 }

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/BoothDetailsFragment.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/BoothDetailsFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.bumptech.glide.Glide
 import com.google.android.material.appbar.AppBarLayout
 import com.hppk.toctw.R
 import com.hppk.toctw.data.model.Booth
@@ -45,6 +44,13 @@ class BoothDetailsFragment : Fragment(), BoothDetailsContract.View {
 
         signInContainer.setOnClickListener {
             findNavController().navigate(BoothDetailsFragmentDirections.actionBoothDetailsFragmentToSignInFragment())
+        }
+        btnMoreReviews.setOnClickListener {
+            findNavController().navigate(
+                BoothDetailsFragmentDirections.actionBoothDetailsFragmentToReviewsFragment(
+                    args.booth
+                )
+            )
         }
     }
 
@@ -128,7 +134,12 @@ class BoothDetailsFragment : Fragment(), BoothDetailsContract.View {
     private fun initRatingReview() {
         ratingBar.setOnRatingBarChangeListener { _, rating, fromUser ->
             if (fromUser) {
-                findNavController().navigate(BoothDetailsFragmentDirections.actionBoothDetailsFragmentToAddRatingFragment(args.booth, rating))
+                findNavController().navigate(
+                    BoothDetailsFragmentDirections.actionBoothDetailsFragmentToAddRatingFragment(
+                        args.booth,
+                        rating
+                    )
+                )
             }
         }
 
@@ -160,6 +171,13 @@ class BoothDetailsFragment : Fragment(), BoothDetailsContract.View {
 
     override fun showSignInButton(visible: Int) {
         signInContainer.visibility = visible
+    }
+
+    override fun showMoreReviewButton(show: Boolean) {
+        btnMoreReviews.visibility = when (show) {
+            true -> View.VISIBLE
+            else -> View.GONE
+        }
     }
 
 }

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/addrating/AddRatingPresenter.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/addrating/AddRatingPresenter.kt
@@ -16,7 +16,7 @@ import io.reactivex.schedulers.Schedulers
 class AddRatingPresenter(
     private val view: AddRatingContract.View,
     private val userRepo: UserRepository = UserRepository(remoteUserDao = FirestoreUserDao()),
-    private val reviewRepo: ReviewRepository = ReviewRepository(FirestoreReviewDao()),
+    private val reviewRepo: ReviewRepository = ReviewRepository(),
     private val ioScheduler: Scheduler = Schedulers.io(),
     private val uiScheduler: Scheduler = AndroidSchedulers.mainThread(),
     private val disposable: CompositeDisposable = CompositeDisposable()

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsContract.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsContract.kt
@@ -1,0 +1,15 @@
+package com.hppk.toctw.ui.booth.details.reviews
+
+import com.hppk.toctw.data.model.Booth
+import com.hppk.toctw.data.model.Review
+
+interface ReviewsContract {
+    interface View {
+        fun onReviewsLoaded(reviews: List<Review>)
+        fun showProgressBar(visibility: Int)
+    }
+
+    interface Presenter {
+        fun getAllReviews(booth: Booth)
+    }
+}

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsFragment.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsFragment.kt
@@ -1,0 +1,60 @@
+package com.hppk.toctw.ui.booth.details.reviews
+
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.hppk.toctw.R
+import com.hppk.toctw.data.model.Review
+import com.hppk.toctw.ui.booth.details.ReviewsAdapter
+import kotlinx.android.synthetic.main.fragment_reviews.*
+
+
+class ReviewsFragment : Fragment(), ReviewsContract.View {
+
+    private val args: ReviewsFragmentArgs by navArgs()
+    private val reviewsAdapter: ReviewsAdapter by lazy { ReviewsAdapter(context!!) }
+    private val presenter: ReviewsContract.Presenter by lazy {
+        ReviewsPresenter(this)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_reviews, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initToolbar()
+
+        rvReviews.layoutManager = LinearLayoutManager(context)
+        rvReviews.adapter = reviewsAdapter
+        presenter.getAllReviews(args.booth)
+    }
+
+    override fun onReviewsLoaded(reviews: List<Review>) {
+        reviewsAdapter.reviews.clear()
+        reviewsAdapter.reviews.addAll(reviews)
+        reviewsAdapter.notifyDataSetChanged()
+    }
+
+    private fun initToolbar() {
+        (activity as AppCompatActivity).let {
+            it.setSupportActionBar(toolbar)
+            it.supportActionBar?.let { actionBar ->
+                actionBar.setDisplayHomeAsUpEnabled(true)
+                actionBar.setTitle(R.string.review)
+            }
+        }
+    }
+
+    override fun showProgressBar(visibility: Int) {
+        progressBar.visibility = visibility
+    }
+
+}

--- a/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsPresenter.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/booth/details/reviews/ReviewsPresenter.kt
@@ -1,0 +1,37 @@
+package com.hppk.toctw.ui.booth.details.reviews
+
+import android.util.Log
+import android.view.View
+import com.hppk.toctw.data.model.Booth
+import com.hppk.toctw.data.repository.ReviewRepository
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+
+class ReviewsPresenter(
+    private val view: ReviewsContract.View,
+    private val reviewRepo: ReviewRepository = ReviewRepository(),
+    private val ioScheduler: Scheduler = Schedulers.io(),
+    private val uiScheduler: Scheduler = AndroidSchedulers.mainThread(),
+    private val disposable: CompositeDisposable = CompositeDisposable()
+) : ReviewsContract.Presenter {
+
+    private val TAG = ReviewsPresenter::class.java.simpleName
+
+    override fun getAllReviews(booth: Booth) {
+        disposable.add(
+            reviewRepo.getReviews(booth)
+                .doOnSubscribe { view.showProgressBar(View.VISIBLE) }
+                .doOnSuccess{ view.showProgressBar(View.GONE) }
+                .subscribeOn(ioScheduler)
+                .observeOn(uiScheduler)
+                .subscribe({
+                    view.onReviewsLoaded(it)
+                }, {t ->
+                    Log.e(TAG, "[TOCTW] getAllReviews - failed: ${t.message}", t)
+                })
+        )
+    }
+
+}

--- a/app/src/main/res/color/selector_more_button.xml
+++ b/app/src/main/res/color/selector_more_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorPrimary" android:state_pressed="true" />
+    <item android:color="@color/colorPrimaryDark" />
+</selector>

--- a/app/src/main/res/drawable-tvdpi/selector_more_button.xml
+++ b/app/src/main/res/drawable-tvdpi/selector_more_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/shape_primary" android:state_pressed="true" />
+    <item android:drawable="@drawable/shape_primary_dark" />
+</selector>

--- a/app/src/main/res/drawable/shape_primary.xml
+++ b/app/src/main/res/drawable/shape_primary.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/colorPrimary" />
+</shape>

--- a/app/src/main/res/drawable/shape_primary_dark.xml
+++ b/app/src/main/res/drawable/shape_primary_dark.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/colorPrimaryDark" />
+</shape>

--- a/app/src/main/res/layout/fragment_booth_details.xml
+++ b/app/src/main/res/layout/fragment_booth_details.xml
@@ -228,6 +228,18 @@
                     app:layout_constraintTop_toBottomOf="@id/divider" />
 
                 <TextView
+                    android:id="@+id/btnMoreReviews"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/selector_more_button"
+                    android:gravity="center"
+                    android:padding="32dp"
+                    android:text="리뷰 더보기"
+                    android:textColor="@color/colorAccent"
+                    app:layout_constraintTop_toBottomOf="@id/rvReviews"
+                    app:layout_constraintBottom_toBottomOf="parent" />
+
+                <TextView
                     android:id="@+id/tvEmptyReviews"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_reviews.xml
+++ b/app/src/main/res/layout/fragment_reviews.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimaryDark"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".ui.booth.details.reviews.ReviewsFragment">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:contentInsetStart="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvReviews"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -133,6 +133,9 @@
         <action
             android:id="@+id/action_boothDetailsFragment_to_signInFragment"
             app:destination="@id/signInFragment" />
+        <action
+            android:id="@+id/action_boothDetailsFragment_to_reviewsFragment"
+            app:destination="@id/reviewsFragment" />
     </fragment>
     <fragment
         android:id="@+id/addRatingFragment"
@@ -152,5 +155,14 @@
         android:name="com.hppk.toctw.ui.signin.SignInFragment"
         android:label="fragment_sign_in"
         tools:layout="@layout/fragment_sign_in" />
+    <fragment
+        android:id="@+id/reviewsFragment"
+        android:name="com.hppk.toctw.ui.booth.details.reviews.ReviewsFragment"
+        android:label="fragment_reviews"
+        tools:layout="@layout/fragment_reviews" >
+        <argument
+            android:name="booth"
+            app:argType="com.hppk.toctw.data.model.Booth" />
+    </fragment>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,8 @@
     <string name="sign_in">로그인</string>
     <string name="tos_pp">\'Google 계정으로 시작하기\'를 통해 시작하시면, \n본 서비스 이용 약관과 개인정보 취급방침에 동의한 것으로 간주됩니다.</string>
 
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="review">리뷰</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,9 +84,6 @@
     <string name="need_signin">로그인이 필요한 기능입니다.</string>
     <string name="sign_in">로그인</string>
     <string name="tos_pp">\'Google 계정으로 시작하기\'를 통해 시작하시면, \n본 서비스 이용 약관과 개인정보 취급방침에 동의한 것으로 간주됩니다.</string>
-
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="review">리뷰</string>
 
 </resources>


### PR DESCRIPTION
기존 구현은 전체 Review를 가져와 보여주는 방식입니다.
Review가 많아지게 되면 모두 가져오는 것은 리소스 낭비가 발생할 수 있습니다.

BoothDetails 화면에서는 최대 3개까지만 보여주고,
대신 more 버튼을 두어 이를 누르면 Reviews 화면으로 넘어가도록 구현하였습니다.

Reviews에서도 별도 pagination을 구현하려다...
오늘은 여기까지만... ㅠㅠ