### PR TITLE
InApp Update 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,8 +16,8 @@ android {
         applicationId "com.hppk.toctw"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 7
-        versionName "1.0.6"
+        versionCode 10
+        versionName "1.0.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField "String", "PHONE_NUMBER_PARK", PHONE_NUMBER_PARK
@@ -53,6 +53,9 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:2.8.47'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    // play core
+    implementation 'com.google.android.play:core:1.6.4'
 
     // Jetpack - CameraX
     implementation "androidx.camera:camera-core:1.0.0-alpha05"

--- a/app/src/main/java/com/hppk/toctw/ui/MainActivity.kt
+++ b/app/src/main/java/com/hppk/toctw/ui/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.hppk.toctw.ui
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
 import androidx.navigation.NavController
@@ -8,12 +10,23 @@ import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.install.model.AppUpdateType.IMMEDIATE
+import com.google.android.play.core.install.model.UpdateAvailability
 import com.hppk.toctw.R
 import kotlinx.android.synthetic.main.activity_main.*
 
+private const val REQUEST_CODE_UPDATE = 1113
+
 class MainActivity : AppCompatActivity() {
-    private lateinit var appBarConfiguration: AppBarConfiguration
+
+    private val TAG = MainActivity::class.java.simpleName
+
     private val navController: NavController by lazy { findNavController(R.id.nav_host_fragment) }
+    private val updateManager: AppUpdateManager by lazy { AppUpdateManagerFactory.create(this) }
+
+    private lateinit var appBarConfiguration: AppBarConfiguration
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,6 +41,23 @@ class MainActivity : AppCompatActivity() {
                 R.id.settingsFragment
             ), drawerLayout
         )
+
+        checkUpdatable()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        updateManager
+            .appUpdateInfo
+            .addOnSuccessListener { appUpdateInfo ->
+                if (appUpdateInfo.updateAvailability()
+                    == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
+                ) {
+                    // If an in-app update is already running, resume the update.
+                    updateManager.startUpdateFlowForResult(appUpdateInfo, IMMEDIATE, this, REQUEST_CODE_UPDATE)
+                }
+            }
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -43,6 +73,40 @@ class MainActivity : AppCompatActivity() {
             drawerLayout.closeDrawers()
         } else {
             super.onBackPressed()
+        }
+    }
+
+    private fun checkUpdatable() {
+        updateManager.appUpdateInfo
+            .addOnFailureListener { t ->
+                Log.e(TAG, "[TOCTW] checkUpdateable - failed: ${t.message}", t)
+            }
+            .addOnSuccessListener { updateInfo ->
+                Log.d(TAG, "[TOCTW] checkUpdateable - updateAvailability: ${getUpdateAvailabilityText(updateInfo.updateAvailability())}")
+
+                if (updateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+                    && updateInfo.isUpdateTypeAllowed(IMMEDIATE)
+                ) {
+                    updateManager.startUpdateFlowForResult(updateInfo, IMMEDIATE, this, REQUEST_CODE_UPDATE)
+                }
+            }
+    }
+
+    private fun getUpdateAvailabilityText(updateAvailability: Int): String =
+        when (updateAvailability) {
+            UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS -> "DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS"
+            UpdateAvailability.UPDATE_AVAILABLE -> "UPDATE_AVAILABLE"
+            UpdateAvailability.UPDATE_NOT_AVAILABLE -> "UPDATE_NOT_AVAILABLE"
+            else -> "UNKNOWN"
+        }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == REQUEST_CODE_UPDATE) {
+            if (resultCode != RESULT_OK) {
+                Log.e(TAG, "Update flow failed! Result code: $resultCode")
+            }
         }
     }
 }


### PR DESCRIPTION
InApp Update 기능을 추가하였습니다.
내부 개발자 버전으로 올려서 테스트해봤고, 대략 잘 되는 것 같긴 합니다만...
계속 확인은 필요할 것 같습니다.

업데이트 가능한 버전이 확인되면 대략 아래와 같이 MainActivity에서 업데이트하라고 창을 띄웁니다.
사용자 선택에 따라 거절하고 기존 버전을 그대로 사용할 수 있습니다.

![Screenshot_20191113-135318_Google Play Store](https://user-images.githubusercontent.com/12050742/68734331-5fd78700-061d-11ea-80e9-f73346cf69d9.jpg)

어제 회의에서 "이왕이면 사용자에게 가장 최신 앱을 보여줘야 하니 금요일날 공개하자" 라는 얘기를 듣고 인앱 업데이트 기능을 제공하면 언제 배포해도 상관없을 것 같아서 추가하고자 합니다.


refer: https://developer.android.com/guide/app-bundle/in-app-updates
